### PR TITLE
Add VideoDownloader

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,7 @@ PowerToys Run is a quick launcher for Windows. It is open-source and modular for
 - [Twitch](https://github.com/hlaueriksson/Community.PowerToys.Run.Plugins#twitch) - Browse, search and view streams on Twitch.<!--lint enable double-link-->
 - [SVGL](https://github.com/SameerJS6/powertoys-svgl) - Browse, search, and copy SVG logos via svgl.
 - [QuickNotes](https://github.com/ruslanlap/CommunityPowerToysRunPlugin-QuickNotes) - Create, manage, and search notes directly from PowerToys Run.
+
 ## Resources
 
 - [Visual Studio Template](https://github.com/8LWXpg/PowerToysRun-PluginTemplate) - Visual Studio template for community plugins.

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ PowerToys Run is a quick launcher for Windows. It is open-source and modular for
 - [Need](https://github.com/hlaueriksson/Community.PowerToys.Run.Plugins#need) - Key-value store for important information.
 - [Twitch](https://github.com/hlaueriksson/Community.PowerToys.Run.Plugins#twitch) - Browse, search and view streams on Twitch.<!--lint enable double-link-->
 - [SVGL](https://github.com/SameerJS6/powertoys-svgl) - Browse, search, and copy SVG logos via svgl.
-
+- [QuickNotes](https://github.com/ruslanlap/CommunityPowerToysRunPlugin-QuickNotes) - Create, manage, and search notes directly from PowerToys Run.
 ## Resources
 
 - [Visual Studio Template](https://github.com/8LWXpg/PowerToysRun-PluginTemplate) - Visual Studio template for community plugins.

--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,7 @@ PowerToys Run is a quick launcher for Windows. It is open-source and modular for
 - [SVGL](https://github.com/SameerJS6/powertoys-svgl) - Browse, search, and copy SVG logos via svgl.
 - [QuickNotes](https://github.com/ruslanlap/CommunityPowerToysRunPlugin-QuickNotes) - Create, manage, and search notes directly from PowerToys Run.
 - [SpeedTest](https://github.com/ruslanlap/PowerToysRun-SpeedTest) - Test your internet connection speed directly from PowerToys Run.
+- [VideoDownloader](https://github.com/ruslanlap/PowerToysRun-VideoDownloader) - Download videos from various platforms directly from PowerToys Run.
 
 ## Resources
 

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,7 @@ PowerToys Run is a quick launcher for Windows. It is open-source and modular for
 - [Twitch](https://github.com/hlaueriksson/Community.PowerToys.Run.Plugins#twitch) - Browse, search and view streams on Twitch.<!--lint enable double-link-->
 - [SVGL](https://github.com/SameerJS6/powertoys-svgl) - Browse, search, and copy SVG logos via svgl.
 - [QuickNotes](https://github.com/ruslanlap/CommunityPowerToysRunPlugin-QuickNotes) - Create, manage, and search notes directly from PowerToys Run.
+- [SpeedTest](https://github.com/ruslanlap/PowerToysRun-SpeedTest) - Test your internet connection speed directly from PowerToys Run.
 
 ## Resources
 


### PR DESCRIPTION
https://github.com/ruslanlap/PowerToysRun-VideoDownloader

VideoDownloader is a PowerToys Run plugin that lets you download videos from various platforms (primarily YouTube) directly from the PowerToys Run interface. Users can simply type 'dl' followed by a video URL to instantly download videos without needing to open a browser.

### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

## Requirements for your pull request

- [x] You have read and understood the [Contribution Guidelines](https://github.com/hlaueriksson/awesome-powertoys-run-plugins/blob/main/contributing.md).
- [x] This pull request has a title in the format 'Add [PluginName]'.
- [x] Your entry includes a short description of the plugin with the first character uppercase and ending with a dot.
- [x] The link text is the name of the plugin and the URL is the link to the GitHub repo.
- [x] Your entry has been added at the bottom of the appropriate category.
- [x] The suggested plugin complies with the below requirements.